### PR TITLE
fix a bug in the untar function

### DIFF
--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -17,7 +17,7 @@ module.exports = (grunt) ->
 			new targz().extract(temp_path, path, (err) ->
 				if(err)
 					deferred.reject { message: 'Error extracting archive' + err }
-				deferred.resolve
+				deferred.resolve()
 			)
 
 		request.get(artifact.buildUrl(), (error, response) ->


### PR DESCRIPTION
Fixes a bug I accidentally introduced; must call writeable.end on the fileStream otherwise weird things happen
