### PR TITLE
Switched from 'finish' to 'close' event on streamWriter when downloading dependencies

### DIFF
--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -8,158 +8,166 @@ urlUtil = require 'url'
 
 module.exports = (grunt) ->
 
-	compress = require('grunt-contrib-compress/tasks/lib/compress')(grunt)
+  compress = require('grunt-contrib-compress/tasks/lib/compress')(grunt)
 
-	extract = (ext, temp_path, path, deferred) ->
-		if ext is 'tgz'
-			new targz().extract(temp_path, path, (err) ->
-				if(err)
-					deferred.reject { message: 'Error extracting archive' + err }
-				deferred.resolve()
-			)
+  extract = (ext, temp_path, path, deferred) ->
+    grunt.verbose.writeln "Extract #{ext} #{temp_path}, #{path}"
+    if ext is 'tgz'
+      @archive = new targz()
+      @archive.extract(temp_path, path, (err) ->
+        grunt.verbose.writeln "Extraction done #{err}"
+        if(err)
+          deferred.reject { message: 'Error extracting archive' + err }
+        deferred.resolve()
+      )
 
-		if ext is 'zip'
-			archive = new zip(temp_path)
-			archive.extractAllTo(path, true);
-			deferred.resolve()
+    if ext is 'zip'
+      archive = new zip(temp_path)
+      archive.extractAllTo(path, true);
+      deferred.resolve()
 
-	downloadFile = (options, artifact, path, temp_path) ->
-		deferred = Q.defer()
+  downloadFile = (options, artifact, path, temp_path) ->
+    deferred = Q.defer()
 
-		file = fs.createWriteStream(temp_path)
-		file.on 'finish', () ->
-			extract artifact.ext, temp_path, path, deferred
+    grunt.log.writeln "Downloading #{artifact.buildUrl()}"
+    file = request.get(artifact.buildUrl(), options, (error, response) ->
+      if error
+        deferred.reject {message: 'Error making http request: ' + error}
+      else if response.statusCode isnt 200
+        deferred.reject {message: 'Request received invalid status code: ' + response.statusCode}
 
-		request.get(artifact.buildUrl(), options, (error, response) ->
-			file.end
-			if error
-				deferred.reject {message: 'Error making http request: ' + error}
-			else if response.statusCode isnt 200
-				deferred.reject {message: 'Request received invalid status code: ' + response.statusCode}
-		).pipe(file)
+      grunt.verbose.writeln "Download complete"
+      file.end
+    ).pipe(fs.createWriteStream(temp_path))
 
-		deferred.promise
+    file.on 'close', ()->
+      grunt.verbose.writeln "Start Extracting..."
+      extract artifact.ext, temp_path, path, deferred
 
-	upload = (data, url, credentials, isFile = true) ->
-		deferred = Q.defer()
+    grunt.verbose.writeln "Downloading ..."
+    deferred.promise
 
-		options = grunt.util._.extend {method: 'PUT', url: url}
-		if credentials.username
-			options = grunt.util._.extend options, {auth: credentials}
+  upload = (data, url, credentials, isFile = true) ->
+    deferred = Q.defer()
 
-		grunt.verbose.writeflags options
+    options = grunt.util._.extend {method: 'PUT', url: url}
+    if credentials.username
+      options = grunt.util._.extend options, {auth: credentials}
 
-		if isFile
-			file = fs.createReadStream(data)
-			file.pipe(request.put(options, (error, response) ->
-				if error
-					deferred.reject {message: 'Error making http request: ' + error}
-				else if response.statusCode is 201
-					deferred.resolve()
-				else
-					deferred.reject {message: 'Request received invalid status code: ' + response.statusCode}
-			))
-		else
-			deferred.resolve()
+    grunt.verbose.writeflags options
 
-		deferred.promise
+    if isFile
+      file = fs.createReadStream(data)
+      file.pipe(request.put(options, (error, response) ->
+        if error
+          deferred.reject {message: 'Error making http request: ' + error}
+        else if response.statusCode is 201
+          deferred.resolve()
+        else
+          deferred.reject {message: 'Request received invalid status code: ' + response.statusCode}
+      ))
+    else
+      deferred.resolve()
 
-	publishFile = (options, filename, urlPath) ->
-		deferred = Q.defer()
+    deferred.promise
 
-		generateHashes(options.path + filename).then (hashes) ->
+  publishFile = (options, filename, urlPath) ->
+    deferred = Q.defer()
 
-			url = urlPath + filename
-			promises = [
-				upload options.path + filename, url, options.credentials
-			]
+    generateHashes(options.path + filename).then (hashes) ->
 
-			Q.all(promises).then () ->
-				deferred.resolve()
-			.fail (error) ->
-				deferred.reject error
-		.fail (error) ->
-			deferred.reject error
+      url = urlPath + filename
+      promises = [
+        upload options.path + filename, url, options.credentials
+      ]
 
-		deferred.promise
+      Q.all(promises).then () ->
+        deferred.resolve()
+      .fail (error) ->
+          deferred.reject error
+    .fail (error) ->
+        deferred.reject error
 
-	generateHashes = (file) ->
-		deferred = Q.defer()
+    deferred.promise
 
-		md5 = crypto.createHash 'md5'
-		sha1 = crypto.createHash 'sha1'
+  generateHashes = (file) ->
+    deferred = Q.defer()
 
-		stream = fs.ReadStream file
+    md5 = crypto.createHash 'md5'
+    sha1 = crypto.createHash 'sha1'
 
-		stream.on 'data', (data) ->
-			sha1.update data
-			md5.update data
+    stream = fs.ReadStream file
 
-		stream.on 'end', (data) ->
-			hashes =
-				md5: md5.digest 'hex'
-				sha1: sha1.digest 'hex'
-			deferred.resolve hashes
+    stream.on 'data', (data) ->
+      sha1.update data
+      md5.update data
 
-		stream.on 'error', (error) ->
-			deferred.reject error
+    stream.on 'end', (data) ->
+      hashes =
+        md5: md5.digest 'hex'
+        sha1: sha1.digest 'hex'
+      deferred.resolve hashes
 
-		deferred.promise
+    stream.on 'error', (error) ->
+      deferred.reject error
 
-	return {
+    deferred.promise
 
-		###*
-		* Download an artifactory artifact and extract it to a path
-		* @param {ArtifactoryArtifact} artifact The artifactory artifact to download
-		* @param {String} path The path the artifact should be extracted to
-		*
-		* @return {Promise} returns a Q promise to be resolved when the file is done downloading
-		###
-		download: (artifact, path, options) ->
-			deferred = Q.defer()
+  return {
 
-			if grunt.file.exists("#{path}/.version") and (grunt.file.read("#{path}/.version").trim() is artifact.version)
-				grunt.log.writeln "Up-to-date: #{artifact}"
-				return
+  ###*
+  * Download an artifactory artifact and extract it to a path
+  * @param {ArtifactoryArtifact} artifact The artifactory artifact to download
+  * @param {String} path The path the artifact should be extracted to
+  *
+  * @return {Promise} returns a Q promise to be resolved when the file is done downloading
+  ###
+  download: (artifact, path, options) ->
+    deferred = Q.defer()
 
-			grunt.file.mkdir path
+    if grunt.file.exists("#{path}/.version") and (grunt.file.read("#{path}/.version").trim() is artifact.version)
+      grunt.log.writeln "Up-to-date: #{artifact}"
+      return
 
-			temp_path = "#{path}/#{artifact.buildArtifactUri()}"
-			grunt.log.writeln "Downloading #{artifact.buildUrl()}"
+    grunt.file.mkdir path
 
-			downloadFile(options, artifact, path, temp_path).then( ->
-				deferred.resolve()
-			).fail (error) ->
-				deferred.reject error
+    temp_path = "#{path}/#{artifact.buildArtifactUri()}"
 
-			deferred.promise
+    downloadFile(options, artifact, path, temp_path).then( ->
+      grunt.log.writeln "Download and unpack done."
+      deferred.resolve()
+    ).fail (error) ->
+      grunt.log.writeln "Download and unpack Error: #{error}"
+      deferred.reject error
 
-		###*
-		* Publish a path to artifactory
-		* @param {ArtifactoryArtifact} artifact The artifactory artifact to publish to artifactory
-		* @param {String} path The path to publish to artifactory
-		*
-		* @return {Promise} returns a Q promise to be resolved when the artifact is done being published
-		###
-		publish: (artifact, files, options) ->
-			deferred = Q.defer()
-			filename = artifact.buildArtifactUri()
-			archive = "#{options.path}#{filename}"
-			
-			if(grunt.util._.endsWith(archive, '.war'))
-				mode = 'zip'
-			else
-				mode = compress.autoDetectMode(archive)
+    deferred.promise
 
-			compress.options =
-				archive: archive
-				mode: mode
+  ###*
+  * Publish a path to artifactory
+  * @param {ArtifactoryArtifact} artifact The artifactory artifact to publish to artifactory
+  * @param {String} path The path to publish to artifactory
+  *
+  * @return {Promise} returns a Q promise to be resolved when the artifact is done being published
+  ###
+  publish: (artifact, files, options) ->
+    deferred = Q.defer()
+    filename = artifact.buildArtifactUri()
+    archive = "#{options.path}#{filename}"
 
-			compress.tar files, () ->
-				publishFile(options, filename, artifact.buildUrlPath()).then( ->
-					deferred.resolve()
-				).fail (error) ->
-					deferred.reject error
+    if(grunt.util._.endsWith(archive, '.war'))
+      mode = 'zip'
+    else
+      mode = compress.autoDetectMode(archive)
 
-			deferred.promise
-	}
+    compress.options =
+      archive: archive
+      mode: mode
+
+    compress.tar files, () ->
+      publishFile(options, filename, artifact.buildUrlPath()).then( ->
+        deferred.resolve()
+      ).fail (error) ->
+        deferred.reject error
+
+    deferred.promise
+  }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-artifactory-artifact",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A grunt plugin that helps with simple artifactory artifacts",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
For some reason (didn't investigate) the "finish" event on writable is not fired and the archive content would never get unpacked.
Switched to "close" event on the WritableStream object returned by pipe to trigger archive extraction.
