### PR TITLE
resolve deferred where downloaded resource is neither a zip or a tgz

### DIFF
--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -21,9 +21,12 @@ module.exports = (grunt) ->
         deferred.resolve()
       )
 
-    if ext is 'zip'
+    else if ext is 'zip'
       archive = new zip(temp_path)
       archive.extractAllTo(path, true);
+      deferred.resolve()
+
+    else
       deferred.resolve()
 
   downloadFile = (options, artifact, path, temp_path) ->


### PR DESCRIPTION
Hi,

Seems that when the downloadFile function is invoked for any file that is not tgz or zip (e.g. jar) the deferred does not get resolved, this means the grunt task never gets informed of success or failure via done().

This works round the issue - not sure whether you would want to rework this so extract is never called in such a use case?

cheers
