### PR TITLE
Adding optional classifier support to artifact ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ artifactory: {
     url: 'http://artifactory.google.com:8080',
     repository: 'jslibraries',
     options: {
-	    fetch: [
-	      { id: 'com.google.js:jquery:tgz:1.8.0', path: 'public/lib/jquery' }
-	    ]
+      fetch: [
+        { id: 'com.google.js:jquery:tgz:1.8.0', path: 'public/lib/jquery' }
+      ]
     }
   }
 }
@@ -110,6 +110,11 @@ Type: `String`
 
 This defines the extension of the artifact. Ex: `tgz`
 
+##### classifier
+Type: `String`
+
+This defines the optional classifier to the artifact name. Ex: `javadoc`
+
 ##### version
 Type: `String`
 
@@ -118,8 +123,8 @@ This defines the version of the artifact. Ex: `1.8.0`
 ##### id
 Type: `String`
 
-This is a shorthand for `group_id`, `name`, `ext` and `version`. This defines the id string of the artifact in the following format:
-```{group_id}:{name}:{ext}:{version}```
+This is a shorthand for `group_id`, `name`, `ext`, `version` and optionally a `classifier`. This defines the id string of the artifact in the following format:
+```{group_id}:{name}:{ext}:[{classifier}:]{version}```
 
 Ex:
 ```

--- a/tasks/artifactory.coffee
+++ b/tasks/artifactory.coffee
@@ -16,7 +16,7 @@ module.exports = (grunt) ->
       url: ''
       base_path: 'artifactory'
       repository: ''
-      versionPattern: '%a-%v.%e'
+      versionPattern: '%a-%v%c.%e'
       username: ''
       password: ''
 


### PR DESCRIPTION
The plugin supports maven style artifacts identified by `group_id`, `name`, `extension` and `version` fields. It would be useful to support the optional [`classifier`](http://maven.apache.org/pom.html#Dependencies) field as well. This could be used, for example, to download sources or javadoc versions of an artifact.

Very new to coffeescript so hope this is ok! Thanks for contributing the plugin.
