### PR TITLE
Bug fix to allow publish task to complete

### DIFF
--- a/tasks/artifactory.coffee
+++ b/tasks/artifactory.coffee
@@ -62,7 +62,7 @@ module.exports = (grunt) ->
                 deferred.reject(err)
         .fail (err) ->
             deferred.reject(err)
-        processes.push deferred
+        processes.push deferred.promise
 
     Q.all(processes).then(() ->
       done()


### PR DESCRIPTION
Hi David,

@mcrmfc and I spotted what looks like a typo bug in the publish task:

The top level deferred was being added to the processes list rather than it's promise. This meant grunt was not waiting for the top level deferred to be resolved before quitting. Typical error:

```
Error: Process exited before Archiver could finish emitting data
    at null.<anonymous> (/Users/ashis/dev/itv/ten-foot/node_modules/grunt-artifactory-artifact/node_modules/grunt-contrib-compress/node_modules/archiver/lib/archiver/core.js:79:13)
    at process.g (events.js:175:14)
    at process.EventEmitter.emit (events.js:117:20)
    at process.exit (node.js:707:17)
    at Object.exit (/Users/ashis/dev/itv/ten-foot/node_modules/grunt/lib/util/exit.js:24:13)
    at Object.task.options.done (/Users/ashis/dev/itv/ten-foot/node_modules/grunt/lib/grunt.js:147:14)
    at Task.<anonymous> (/Users/ashis/dev/itv/ten-foot/node_modules/grunt/lib/util/task.js:261:25)
    at Task.<anonymous> (/Users/ashis/dev/itv/ten-foot/node_modules/grunt/lib/util/task.js:215:7)
    at null._onTimeout (/Users/ashis/dev/itv/ten-foot/node_modules/grunt/lib/util/task.js:225:33)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
```

Cheers, Ash
