### PR TITLE
Bug fix to ensure that the publish task completes cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ artifactory: {
   client: {
     files: [
       { src: ['builds/**/*'] }
-    ]
+    ],
     options: {
       publish: [{
           id: 'com.mycompany.js:built-artifact:tgz',

--- a/tasks/artifactory.coffee
+++ b/tasks/artifactory.coffee
@@ -57,7 +57,7 @@ module.exports = (grunt) ->
         deferred = Q.defer()
         util.package(artifact, @files, { path: cfg.path }).then () ->
             util.publish(artifact, { path: cfg.path, credentials: { username: options.username, password: options.password }}).then ()->
-                deferred.resolve
+                deferred.resolve()
             .fail (err) ->
                 deferred.reject(err)
         .fail (err) ->


### PR DESCRIPTION
Hi David,

It looks like we need one small but important change for the previous bug fix: (https://github.com/leedavidr/grunt-artifactory-artifact/pull/10)

The deferred wasn't being correctly resolved for the publish task so grunt wouldn't finish cleanly: You would notice if you had any other tasks after publish.

Cheers, Ash
