### PR TITLE
Reset compress options before calling autoDetectMode

### DIFF
--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -168,6 +168,7 @@ module.exports = (grunt) ->
     if(_s.endsWith(archive, '.war'))
       mode = 'zip'
     else
+      compress.options = {}
       mode = compress.autoDetectMode(archive)
 
     compress.options =


### PR DESCRIPTION
If you try running two artifactory:package commands one after another, but with two different archive formats (say tgz then zip), the plugin will incorrectly compress your zip as a tgz (or whichever format runs first).

This is because grunt-contrib-compress's utility class returns exports.options.mode as the first statement in the function "compress.autoDetectMode." For example, here's the code you will find in grunt-contrib-compress:

if (exports.options.mode) {
      return exports.options.mode;
 }

All that is needed is to reset the options before calling compress.autoDetectMode.

Thanks! Let me know if you have more questions.