### PR TITLE
Allow specifying a fully-qualified download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Type: `String`
 This is a shorthand for `group_id`, `name`, `ext`, `version` and optionally a `classifier`. This defines the id string of the artifact in the following format:
 ```{group_id}:{name}:{ext}:[{classifier}:]{version}```
 
+##### download_url
+Type: `String`
+
+If you have a custom URL scheme for your artifactory instance, you can specify a full-qualified URL for downloading an artifact. You still need to set the `ext` param for extraction purposes.
+
 Ex:
 ```
 com.google.js:jquery:tgz:1.8.0

--- a/lib/artifactory-artifact.coffee
+++ b/lib/artifactory-artifact.coffee
@@ -15,7 +15,7 @@ module.exports = (grunt) -> class ArtifactoryArtifact
 		return config
 
 	constructor: (config) ->
-		{@url, @base_path, @repository, @group_id, @name, @classifier, @version, @ext, @versionPattern} = config
+		{@url, @base_path, @download_url, @repository, @group_id, @name, @classifier, @version, @ext, @versionPattern} = config
 
 	toString: () ->
 		parts = [@group_id, @name, @ext, @version]
@@ -37,7 +37,10 @@ module.exports = (grunt) -> class ArtifactoryArtifact
 		])).join('/')
 
 	buildUrl: () ->
-		"#{@buildUrlPath()}#{@buildArtifactUri()}"
+		if @download_url
+			@download_url
+		else
+			"#{@buildUrlPath()}#{@buildArtifactUri()}"
 
 	buildArtifactUri: () ->
 		@versionPattern.replace /%([avce])/g, ($0, $1) =>


### PR DESCRIPTION
This is to support users that have a custom artifactory URL scheme.