### PR TITLE
deps: update grunt-contrib-compress

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "q": "0.9.3",
     "grunt": "~0.4.1",
-    "grunt-contrib-compress": "~0.5.2",
+    "grunt-contrib-compress": "~0.13.0",
     "request": "~2.27.0",
     "tar.gz": "~0.1.1",
     "adm-zip": "~0.4.3",


### PR DESCRIPTION
been getting "Fatal error: Process exited before Archiver could finish emitting data". After googling around, saw [this issue](https://github.com/gruntjs/grunt-contrib-compress/issues/86) that described a fix appearing in [archiver@0.9.0](https://github.com/archiverjs/node-archiver/commit/59f391ea27a312a2b9fa9e27a880b8e559c4f792), which was first available in [grunt-contrib-compress@0.9.0](https://github.com/gruntjs/grunt-contrib-compress/commit/afb3cd33d553fd4b2ef7310930f0a6010d633c25).