### PR TITLE
Fix peerDependencies breaking under npm2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "q": "0.9.3",
     "grunt": "~0.4.1",
-    "grunt-contrib-compress": "~0.13.0",
+    "grunt-contrib-compress": "~1.2.0",
     "request": "~2.27.0",
     "tar.gz": "~0.1.1",
     "adm-zip": "~0.4.3",


### PR DESCRIPTION
v1 of grunt dropped and broke a lot of npm2 builds that set peerDependency of grunt below v1. grunt-contrib-compress was one of them.