### PR TITLE
Fixes security vulnerability warnings when installing grunt-artifactory-artifact

### DIFF
--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -1,5 +1,5 @@
 request = require 'request'
-targz = require 'tar.gz'
+targz = require 'tar'
 zip = require 'adm-zip'
 fs = require 'fs'
 Q = require 'q'

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "q": "0.9.3",
     "grunt": "~1.0.0",
     "grunt-contrib-compress": "~1.3.0",
-    "request": "~2.27.0",
-    "tar.gz": "~0.1.1",
+    "request": "~2.88.0",
+    "tar": "2.x",
     "adm-zip": "~0.4.3",
-    "lodash": "~2.4.1",
+    "lodash": ">=4.17.5",
     "underscore.string": "~2.3.3"
   },
   "readme": "# grunt-artifactory-artifact\n\n> Forked from grunt-nexus-artifact by Nicholas Boll\n",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-artifactory-artifact",
-  "version": "1.0.1",
+  "version": "2.0.0-rc.0",
   "description": "A grunt plugin that helps with simple artifactory artifacts",
   "main": "index.js",
   "scripts": {

--- a/tasks/artifactory.coffee
+++ b/tasks/artifactory.coffee
@@ -21,7 +21,7 @@ module.exports = (grunt) ->
 
     processes = []
 
-    if !@args.length or _.contains @args, 'fetch'
+    if !@args.length or _.includes @args, 'fetch'
       _.forEach options.fetch, (cfg) ->
         # get the base artifactory path
         _.assign cfg, ArtifactoryArtifact.fromString(cfg.id) if cfg.id
@@ -33,7 +33,7 @@ module.exports = (grunt) ->
           reqOpts = {'auth':{'user':options.username, 'pass':options.password}}
         processes.push util.download(artifact, cfg.path, reqOpts, cfg.decompress)
 
-    if @args.length and _.contains @args, 'package'
+    if @args.length and _.includes @args, 'package'
       _.forEach options.publish, (cfg) =>
         artifactCfg = {}
 
@@ -43,7 +43,7 @@ module.exports = (grunt) ->
         artifact = new ArtifactoryArtifact artifactCfg
         processes.push util.package(artifact, @files, { path: cfg.path } )
 
-    if @args.length and _.contains @args, 'publish'
+    if @args.length and _.includes @args, 'publish'
       _.forEach options.publish, (cfg) =>
         artifactCfg = {}
         _.assign artifactCfg, ArtifactoryArtifact.fromString(cfg.id) if cfg.id


### PR DESCRIPTION
When installing grunt-artifactory-artifact@1.0.1:

```
npm WARN deprecated tar.gz@0.1.1: ⚠️  WARNING ⚠️ tar.gz module has been deprecated and your application is vulnerable. Please use tar module instead: https://npmjs.com/tar
npm WARN deprecated node-uuid@1.4.8: Use uuid module instead
```

`npm ls tar.gz@0.1.1 node-uuid@1.4.8`
```
└─┬ grunt-artifactory-artifact@1.0.1
  ├─┬ request@2.27.0
  │ └── node-uuid@1.4.8
  └── tar.gz@0.1.1
```

This updates the dependencies to versions without known security vulnerabilities.