### PR TITLE
Fix identation error

### DIFF
--- a/lib/artifactory-artifact.coffee
+++ b/lib/artifactory-artifact.coffee
@@ -24,7 +24,7 @@ module.exports = (grunt) -> class ArtifactoryArtifact
 		parts.join(':')
 
 	dashClassifier: () ->
-	 	if @classifier then "-#{@classifier}" else ''
+		if @classifier then "-#{@classifier}" else ''
 
 	buildUrlPath: () ->
 		_.compact(_.flatten([


### PR DESCRIPTION
artifactory-artifact.coffee:27:4: error: mixed indentation
>> 	 	if @classifier then "-#{@classifier}" else ''
There was 1 extra space